### PR TITLE
SM-5823: Make area attribute optional

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -12,7 +12,7 @@ const objectMessageServiceDelegator: ObjectMessageServiceDelegator = iocContaine
 export const handler: SQSHandler = async(event: SQSEvent) => {
   const sqsRecord: SQSRecord = event.Records[0]
   const sqsMessage: EventNotifierSQSMessage = JSON.parse(sqsRecord.body)
-  logger.log(`Received message: ${JSON.stringify(sqsRecord)}`)
+  logger.logWithObject('Received message:', sqsRecord)
 
   try {
     await objectMessageServiceDelegator.getObjectMessageService(sqsMessage.object_type).sendMessageToSNS(sqsMessage, new Date())

--- a/src/mappers/snsPublishInputMapper.ts
+++ b/src/mappers/snsPublishInputMapper.ts
@@ -27,7 +27,7 @@ export default class SNSPublishInputMapper {
   }
 
   private generateMessageAttributes(workData: EventNotifierWorkData): MessageAttributeMap {
-    return {
+    const attributes: MessageAttributeMap = {
       [USRN] : {
         DataType: 'Number',
         StringValue: workData.usrn
@@ -40,15 +40,20 @@ export default class SNSPublishInputMapper {
         DataType: 'String',
         StringValue: workData.promoter_swa_code
       },
-      [AREA]: {
-        DataType: 'String',
-        StringValue: workData.area_name
-      },
       [ACTIVITY_TYPE]: {
         DataType: 'String',
         StringValue: workData.activity_type
       }
     }
+
+    if (workData.area_name) {
+      attributes[AREA] = {
+          DataType: 'String',
+          StringValue: workData.area_name
+      }
+    }
+
+    return attributes
   }
 
   private getTopic(eventType: EventTypeNotificationEnum): string {

--- a/src/services/permitObjectMessageService.ts
+++ b/src/services/permitObjectMessageService.ts
@@ -26,7 +26,7 @@ export default class PermitObjectMessageService implements ObjectMessageService 
     try {
       await this.snsService.publishMessage(await this.mapper.mapToSNSPublishInput(sqsMessage))
 
-      this.logger.log(`Message successfully sent to SNS: ${this.generateLogMessage(sqsMessage, timeReceived)}`)
+      this.logger.logWithObject('Message successfully sent to SNS:', this.generateLogMessage(sqsMessage, timeReceived))
     } catch (err) {
       return Promise.reject(err)
     }

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -7,6 +7,10 @@ export default class Logger {
     console.log(message)
   }
 
+  public logWithObject(message: string, object: any): void {
+    console.log(message, object)
+  }
+
   public error(message: string): void {
     console.error(message)
   }

--- a/tests/unit/mappers/snsPublishInputMapperTests.ts
+++ b/tests/unit/mappers/snsPublishInputMapperTests.ts
@@ -21,7 +21,7 @@ describe('SNSPublishInputMapper', () => {
   let startARN: string
   let stopARN: string
 
-  before(() => {
+  beforeEach(() => {
     sqsMessage = generateSQSMessage()
     snsMessage = generateSNSMessage()
 
@@ -52,6 +52,20 @@ describe('SNSPublishInputMapper', () => {
       assert.equal(result.TopicArn, startARN)
       assert.equal(result.MessageAttributes[USRN].StringValue, snsMessage.object_data.usrn)
       assert.equal(result.MessageAttributes[AREA].StringValue, snsMessage.object_data.area_name)
+      assert.equal(result.MessageAttributes[HA_ORG].StringValue, snsMessage.object_data.highway_authority_swa_code)
+      assert.equal(result.MessageAttributes[PROMOTER_ORG].StringValue, snsMessage.object_data.promoter_swa_code)
+      assert.equal(result.MessageAttributes[ACTIVITY_TYPE].StringValue, snsMessage.object_data.activity_type)
+    })
+
+    it('should not map the Area attribute to AWS publish input object if not provided', async () => {
+      snsMessage.object_data.area_name = null
+
+      const result: SNS.PublishInput = await snsPublishInputMapper.mapToSNSPublishInput(sqsMessage)
+
+      assert.equal(result.Message, JSON.stringify(snsMessage))
+      assert.equal(result.TopicArn, startARN)
+      assert.equal(result.MessageAttributes[USRN].StringValue, snsMessage.object_data.usrn)
+      assert.isUndefined(result.MessageAttributes[AREA])
       assert.equal(result.MessageAttributes[HA_ORG].StringValue, snsMessage.object_data.highway_authority_swa_code)
       assert.equal(result.MessageAttributes[PROMOTER_ORG].StringValue, snsMessage.object_data.promoter_swa_code)
       assert.equal(result.MessageAttributes[ACTIVITY_TYPE].StringValue, snsMessage.object_data.activity_type)

--- a/tests/unit/services/permitObjectMessageServiceTests.ts
+++ b/tests/unit/services/permitObjectMessageServiceTests.ts
@@ -1,11 +1,15 @@
 import 'mocha'
-import { mock, instance, when, verify, anything } from 'ts-mockito'
-import PermitObjectMessageService from '../../../src/services/permitObjectMessageService'
+import { mock, instance, when, verify, capture } from 'ts-mockito'
+import PermitObjectMessageService, { EventLogMessage } from '../../../src/services/permitObjectMessageService'
 import SNSService from '../../../src/services/aws/snsService'
 import SNSPublishInputMapper from '../../../src/mappers/snsPublishInputMapper'
 import Logger from '../../../src/utils/logger'
 import { generatePublishInput } from '../../fixtures/publishInputFixtures'
 import { generateSQSMessage } from '../../fixtures/sqsFixtures'
+import { EventNotifierSQSMessage } from 'street-manager-data'
+import { SNS } from 'aws-sdk'
+import { ArgCaptor2 } from 'ts-mockito/lib/capture/ArgCaptor'
+import { assert } from 'chai'
 
 describe('PermitObjectMessageService', () => {
   let permitObjectMessageService: PermitObjectMessageService
@@ -27,13 +31,24 @@ describe('PermitObjectMessageService', () => {
 
   describe('sendMessageToSNS', () => {
     it('should build an SNS message, send it and log the success', async () => {
-      when(snsPublishInputMapper.mapToSNSPublishInput(anything())).thenResolve(generatePublishInput())
-      when(snsService.publishMessage(anything())).thenResolve()
+      const snsMessage: EventNotifierSQSMessage = generateSQSMessage()
+      const publishInput: SNS.PublishInput =  generatePublishInput()
+      const timeReceived: Date = new Date()
 
-      await permitObjectMessageService.sendMessageToSNS(generateSQSMessage(), new Date())
+      when(snsPublishInputMapper.mapToSNSPublishInput(snsMessage)).thenResolve(publishInput)
+      when(snsService.publishMessage(publishInput)).thenResolve()
 
-      verify(logger.log(anything())).once()
-      verify(snsService.publishMessage(anything())).once()
+      await permitObjectMessageService.sendMessageToSNS(snsMessage, timeReceived)
+
+      const argCaptor: ArgCaptor2<string, EventLogMessage> = capture<string, EventLogMessage>(logger.logWithObject)
+      const [message, eventLog] = argCaptor.first()
+
+      assert.equal(message, 'Message successfully sent to SNS:')
+      assert.equal(eventLog.event_reference, snsMessage.event_reference)
+      assert.equal(eventLog.object_reference, snsMessage.object_reference)
+      assert.equal(eventLog.time_message_received, timeReceived)
+
+      verify(snsService.publishMessage(publishInput)).once()
     })
   })
 })


### PR DESCRIPTION
## Description

- Only map AREA message attribute if provided on work
- Tided up logging
- - New method for logging with object instead of stringifying 
## Coding Standards

Style guide: https://github.com/departmentfortransport/street-manager/wiki/Street-Manager-Style-Guide
Coding best practices: https://github.com/departmentfortransport/street-manager/wiki/Street-Manager-Coding-Best-Practices

## Checklist

- [x] All unit tests passing
- [x] Code coverage suitable
- [x] Branch named {feature|hotfix|task}/{SM-.*}
- [ ] If your pull request depends on any other, please link them
- [ ] Changes approved by your team
- [ ] Changes approved by another team
- [ ] Significant events are being logged e.g. error scenarios
- [ ] Commit messages are meaningful
- [ ] Target is green https://circleci.com/gh/departmentfortransport/street-manager-event-notifier/tree/master
- [ ] Int UI tests passing https://circleci.com/gh/departmentfortransport/street-manager-int/tree/master
- [ ] Add `DO NOT MERGE` if you want to postpone merge
