### PR TITLE
Upgrade lodash to ^4.17.20 to patch a vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2039,9 +2039,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.19",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
-      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
+      "version": "4.17.20",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
     },
     "lodash.flattendeep": {
       "version": "4.4.0",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "inversify": "^5.0.1",
     "knex": "^0.20.15",
     "knex-postgis": "^0.7.0",
+    "lodash": "^4.17.20",
     "moment-timezone": "^0.5.31",
     "pg": "^7.18.2",
     "reflect-metadata": "^0.1.13",


### PR DESCRIPTION
## Description

Based on pen test results

## Evidence

Validated the lambda still works for activities and permits on the feature build environment as demonstrated by the events published on S3 (see screenshot)

![Screenshot 2020-09-15 at 12 12 21](https://user-images.githubusercontent.com/2773538/93203832-f77d9880-f74c-11ea-9b1d-a0328e8ffd10.png)